### PR TITLE
fix file info cache with right sequence number

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/model/CacheFileInfo.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/model/CacheFileInfo.java
@@ -81,7 +81,7 @@ public class CacheFileInfo {
   }
 
   public static CacheFileInfo convert(DataFile amsFile, TableIdentifier identifier,
-      String tableType, Snapshot snapshot) {
+      String tableType, Snapshot snapshot, Long sequence) {
     String partitionName = StringUtils.isEmpty(partitionToPath(amsFile.getPartition())) ?
         "" :
         partitionToPath(amsFile.getPartition());
@@ -94,7 +94,7 @@ public class CacheFileInfo {
     String producer =
         snapshot.summary().getOrDefault(SnapshotSummary.SNAPSHOT_PRODUCER, SnapshotSummary.SNAPSHOT_PRODUCER_DEFAULT);
     return new CacheFileInfo(primaryKeyMd5, identifier, snapshot.snapshotId(),
-        parentId, null, snapshot.sequenceNumber(),
+        parentId, null, sequence == null ? snapshot.sequenceNumber() : sequence,
         tableType, amsFile.getPath(), amsFile.getFileType(), amsFile.getFileSize(), amsFile.getMask(),
         amsFile.getIndex(), amsFile.getSpecId(), partitionName, snapshot.timestampMillis(),
         amsFile.getRecordCount(), snapshot.operation(), producer);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

*(For example: The Arctic Flink dataStream API has already supported this configuration: 'scan.startup.mode', but it is not available with Flink SQL. We should expose this configuration to users when they are using Flink SQL.)*

## Brief change log

*(For example:)*
  - *Add the 'scan.startup.mode' configuration to the ArcticScanContext in the flink modules*
  - *The flink 1.12 and 1.14 versions are affected.*
  - *Add the documentation in the flink chapter*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
